### PR TITLE
Do not decode frames when websocket is in "closing" state

### DIFF
--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -181,7 +181,7 @@ public abstract class WebSocketClient extends WebSocketAdapter implements Runnab
 		int readBytes;
 
 		try {
-			while ( !isClosed() && ( readBytes = istream.read( rawbuffer ) ) != -1 ) {
+			while ( !isClosing() && !isClosed() && ( readBytes = istream.read( rawbuffer ) ) != -1 ) {
 				engine.decode( ByteBuffer.wrap( rawbuffer, 0, readBytes ) );
 			}
 			engine.eot();


### PR DESCRIPTION
My colleague and I noticed that when the handshake request fails (e.g. when the server sends back an HTTP status code of 400), the client hangs. Tracing the code we found that this is because the socket never fully closes. 

If the handshake fails, the websocket engine's internal state is set to "closing". Presumably the next thing that should happen is the `eot` cleanup. However, this can never be reached because the loop to consume more bytes from the socket only breaks when the client is fully "closed". This change makes sure that the client also does not wait to read more bytes if the client is in the process of shutting down.
